### PR TITLE
Add a proxy fallback init option

### DIFF
--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -4,8 +4,11 @@ import MerlinFeedback from './MerlinFeedback.js';
 
 type SerpRegex = RegExp | (url: string) => boolean;
 
+type FallbackOptions = {mode: string; url?: string};
+
 type MerlinFeedbackOptions = {
   useUrlChangeTracker: boolean;
+  fallback?: FallbackOptions
 };
 
 const ERROR_MSG: string = `merlinFeedback takes 4 required arguments: company, environment, instance, serpRegex.
@@ -26,8 +29,13 @@ export default function init(
   if (!company || !env || !instance) throw new Error(ERROR_MSG);
   if (!(serpRegex instanceof RegExp || typeof serpRegex === 'function')) throw new Error(SERP_ERROR_MSG);
 
-  const {useUrlChangeTracker} = options;
+  const {useUrlChangeTracker, fallback} = options;
+  let url = `https://search-${env}.search.blackbird.am/v1/${company}.${env}.${instance}/products/feedback`;
 
-  const url = `https://search-${env}.search.blackbird.am/v1/${company}.${env}.${instance}/products/feedback`;
+  if (fallback && fallback.mode === 'proxy' && fallback.url) {
+    const fallbackUrl = fallback.url;
+    url = `${fallbackUrl.endsWith('/') ? fallbackUrl.slice(0, -1) : fallbackUrl}/${url}`;
+  }
+
   return new MerlinFeedback(url, serpRegex, window.localStorage, BB_CART, useUrlChangeTracker);
 }


### PR DESCRIPTION
@davis 👍 

## Summary
We're noticing CORS issues with some of the requests not going through on our production environment. This pull request should solve the issue by using a fallback the same way merlin.js does.

Illustration:
![cors_errors](https://cloud.githubusercontent.com/assets/2470945/16713840/a67f5976-46b3-11e6-9a12-c54573b9a806.png)

## Tests
Not sure how to set up the tests locally. If you give me a hint I can give it a try.

## Todo
- [ ] Update README